### PR TITLE
Update the path for input json file

### DIFF
--- a/CreateDrawing/CreateDrawingPlugin/SampleAutomation.cs
+++ b/CreateDrawing/CreateDrawingPlugin/SampleAutomation.cs
@@ -54,7 +54,7 @@ namespace CreateDrawingPlugin
             //string inputPath = System.IO.Path.Combine(currDir, @"../../inputFiles", "params.json");
             //Dictionary<string, string> options = JsonConvert.DeserializeObject<Dictionary<string, string>>(System.IO.File.ReadAllText(inputPath));
 
-            Dictionary<string, string> options = JsonConvert.DeserializeObject<Dictionary<string, string>>(System.IO.File.ReadAllText("inputParams.json"));
+            Dictionary<string, string> options = JsonConvert.DeserializeObject<Dictionary<string, string>>(System.IO.File.ReadAllText(Path.Combine(currDir,"inputParams.json")));
             string inputFile = options["inputFile"];
             string projectFile = options["projectFile"];
             string rule = options["runRule"];


### PR DESCRIPTION
When I run the function of creating drawing file, I encounter below error.

[11/11/2019 10:26:25] InventorCoreConsole.exe Information: 0 : Getting Inventor plug-in.
[11/11/2019 10:26:25] InventorCoreConsole.exe Information: 0 : Plug-in: CreateDrawingPlugin
[11/11/2019 10:26:25]     InventorCoreConsole.exe Information: 0 : Activating plug-in: CreateDrawingPlugin
[11/11/2019 10:26:25]     InventorCoreConsole.exe Information: 0 : : CreateDrawingPlugin (1.0.0.0): initializing...
[11/11/2019 10:26:25]     InventorCoreConsole.exe Information: 0 : Executing 'Run' method on Automation object.
[11/11/2019 10:26:25]     InventorCoreConsole.exe Information: 0 : Creating Drawing from iLogic rule...
[11/11/2019 10:26:25]     InventorCoreConsole.exe Information: 0 : currDir: T:\Aces\Jobs\7dc2ff6d536b4df3b001a737d8f74f98
[11/11/2019 10:26:25]     InventorCoreConsole.exe Information: 0 : Deactivating plug-in: CreateDrawingPlugin
[11/11/2019 10:26:25]     InventorCoreConsole.exe Information: 0 : : CreateDrawingPlugin: deactivating...
[11/11/2019 10:26:25] Could not find a part of the path 'T:\Aces\inputFiles\params.json'.
[11/11/2019 10:26:25]
[11/11/2019 10:26:25] The process 3196 ended.

To correct it, I update the path  for input json file